### PR TITLE
Add basic Streamlit shell with main page and DB status

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,39 @@
+import streamlit as st
+
+from main import get_motherduck_connection
+from pages import mainpage
+
+PAGES = {
+    "Главная": mainpage,
+}
+
+
+def _get_connection_status():
+    try:
+        conn = get_motherduck_connection()
+        return conn, "Подключено"
+    except Exception as e:
+        return None, f"Ошибка: {e}"
+
+
+def main():
+    st.set_page_config(page_title="StreamDuck", layout="wide")
+
+    # Sidebar navigation
+    st.sidebar.title("Навигация")
+    page_name = st.sidebar.selectbox("Страница", list(PAGES.keys()))
+
+    # Database connection status
+    conn, status = _get_connection_status()
+    if conn:
+        st.sidebar.success(status)
+    else:
+        st.sidebar.error(status)
+
+    # Render selected page
+    page_module = PAGES[page_name]
+    page_module.render(conn)
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/mainpage.py
+++ b/pages/mainpage.py
@@ -1,0 +1,11 @@
+import streamlit as st
+
+
+def render(conn):
+    """Render the main dashboard page."""
+    st.title("StreamDuck Dashboard")
+    st.write("Это базовая главная страница для будущего дашборда.")
+    if conn is not None:
+        st.success("Соединение с БД активно")
+    else:
+        st.warning("Нет подключения к БД")


### PR DESCRIPTION
## Summary
- add `app.py` entrypoint for Streamlit
- add initial `mainpage` with placeholder dashboard
- show MotherDuck connection status and allow sidebar page selection

## Testing
- `uv run python -m py_compile main.py app.py pages/mainpage.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc6129c920832593fa6e31928bdea2